### PR TITLE
Feature/masonry layout

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -54,11 +54,14 @@
         "prev": "*",
         "next": ["interface", "type"]
       },
+
       {
         "blankLine": "always",
         "prev": ["interface", "type"],
         "next": "*"
-      }
+      },
+      { "blankLine": "always", "prev": "*", "next": "return" },
+      { "blankLine": "always", "prev": "*", "next": "export" }
     ],
     "react/function-component-definition": [
       2,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,8 @@
 import { type ReactElement } from 'react';
-import styles from '@scss/app.module.scss';
 import classNames from 'classnames/bind';
 import { Outlet } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import styles from './scss/app.module.scss';
 import Sidenav from './components/Sidenav';
 import ThemeProvider from './context/ThemeProvider';
 

--- a/src/components/GalleryHome/GalleryHome.module.scss
+++ b/src/components/GalleryHome/GalleryHome.module.scss
@@ -1,7 +1,5 @@
 @use '/src/scss/utils/utils.scss' as utils;
 
-$gallery-spacing: utils.rem(30);
-
 .gallery-home {
   display: grid;
   grid-auto-rows: utils.rem(10);

--- a/src/components/GalleryHome/GalleryHome.module.scss
+++ b/src/components/GalleryHome/GalleryHome.module.scss
@@ -1,10 +1,13 @@
 @use '/src/scss/utils/utils.scss' as utils;
 
-$gallery-spacing: utils.rem(30);
-
 .gallery {
   display: grid;
-  gap: $gallery-spacing;
-  padding: $gallery-spacing;
-  // TODO expand with masonry layout
+  grid-auto-rows: utils.rem(10);
+  grid-template-columns: repeat(auto-fill, minmax(utils.rem(270), 1fr));
+  padding: utils.rem(15);
+
+  @media (width <= 670px) {
+    grid-auto-rows: auto;
+    grid-template-columns: 1fr;
+  }
 }

--- a/src/components/GalleryHome/GalleryHome.tsx
+++ b/src/components/GalleryHome/GalleryHome.tsx
@@ -12,7 +12,7 @@ import GalleryPicture from '../GalleryPicture';
 const cx = classNames.bind(styles);
 
 const GalleryHomeContent = (): ReactElement[] | null => {
-  const { data } = useGetPhotosList(1, PICTURES_PER_PAGE); // TODO - to change props with pagination/infinite scroll values
+  const { data } = useGetPhotosList(2, PICTURES_PER_PAGE); // TODO - to change props with pagination/infinite scroll values. using page 2 because page 1 is only landscape pictures and masonry is not visible
 
   return data && data.length > 0 ? data.map((item) => <GalleryPicture key={item.id} apiItem={item} />) : null;
 };

--- a/src/components/GalleryPicture/GalleryPicture.constants.ts
+++ b/src/components/GalleryPicture/GalleryPicture.constants.ts
@@ -1,0 +1,1 @@
+export const GALLERY_PICTURE_REDUCED_WIDTH = 500;

--- a/src/components/GalleryPicture/GalleryPicture.enums.ts
+++ b/src/components/GalleryPicture/GalleryPicture.enums.ts
@@ -1,0 +1,4 @@
+export const GALLERY_PICTURE_VARIANTS = {
+  LANDSCAPE: 'landscape',
+  PORTRAIT: 'portrait',
+} as const;

--- a/src/components/GalleryPicture/GalleryPicture.logic.ts
+++ b/src/components/GalleryPicture/GalleryPicture.logic.ts
@@ -1,0 +1,14 @@
+import { GALLERY_PICTURE_REDUCED_WIDTH } from './GalleryPicture.constants';
+import { GALLERY_PICTURE_VARIANTS } from './GalleryPicture.enums';
+
+export const getGalleryPictureVariant = (width: number, height: number): string => {
+  const aspectRatio = width / height;
+  if (aspectRatio > 1) return GALLERY_PICTURE_VARIANTS.LANDSCAPE;
+  return GALLERY_PICTURE_VARIANTS.PORTRAIT;
+};
+export const getGalleryPictureReducedImageUrl = (id: string, width: number, height: number): string => {
+  const aspectRatio = width / height;
+  const heightReduced = Math.round(GALLERY_PICTURE_REDUCED_WIDTH / aspectRatio);
+
+  return `https://picsum.photos/id/${id}/${GALLERY_PICTURE_REDUCED_WIDTH}/${heightReduced}`;
+};

--- a/src/components/GalleryPicture/GalleryPicture.logic.ts
+++ b/src/components/GalleryPicture/GalleryPicture.logic.ts
@@ -1,11 +1,13 @@
 import { GALLERY_PICTURE_REDUCED_WIDTH } from './GalleryPicture.constants';
 import { GALLERY_PICTURE_VARIANTS } from './GalleryPicture.enums';
+import type { GalleryPictureVariant } from './GalleryPicture.types';
 
-export const getGalleryPictureVariant = (width: number, height: number): string => {
+export const getGalleryPictureVariant = (width: number, height: number): GalleryPictureVariant => {
   const aspectRatio = width / height;
-  if (aspectRatio > 1) return GALLERY_PICTURE_VARIANTS.LANDSCAPE;
-  return GALLERY_PICTURE_VARIANTS.PORTRAIT;
+
+  return aspectRatio > 1 ? GALLERY_PICTURE_VARIANTS.LANDSCAPE : GALLERY_PICTURE_VARIANTS.PORTRAIT;
 };
+
 export const getGalleryPictureReducedImageUrl = (id: string, width: number, height: number): string => {
   const aspectRatio = width / height;
   const heightReduced = Math.round(GALLERY_PICTURE_REDUCED_WIDTH / aspectRatio);

--- a/src/components/GalleryPicture/GalleryPicture.module.scss
+++ b/src/components/GalleryPicture/GalleryPicture.module.scss
@@ -1,0 +1,19 @@
+@use '/src/scss/utils/utils.scss' as utils;
+
+.gallery-picture {
+  padding: utils.rem(15);
+
+  &--landscape {
+    grid-row: span 18;
+  }
+
+  &--portrait {
+    grid-row: span 36;
+  }
+
+  img {
+    height: 100%;
+    object-fit: cover;
+    width: 100%;
+  }
+}

--- a/src/components/GalleryPicture/GalleryPicture.tsx
+++ b/src/components/GalleryPicture/GalleryPicture.tsx
@@ -1,5 +1,10 @@
 import type { GalleryPictureApiItem } from '@hooks/useGallery.types';
 import type { ReactElement } from 'react';
+import classNames from 'classnames/bind';
+import styles from './GalleryPicture.module.scss';
+import { getGalleryPictureReducedImageUrl, getGalleryPictureVariant } from './GalleryPicture.logic';
+
+const cx = classNames.bind(styles);
 
 type GalleryPictureProps = {
   apiItem: GalleryPictureApiItem;
@@ -7,8 +12,13 @@ type GalleryPictureProps = {
 
 const GalleryPicture = ({ apiItem }: GalleryPictureProps): ReactElement => {
   const alt = `Photo ${apiItem.author} ${apiItem.id}`;
-
-  return <img src={apiItem.download_url} alt={alt} />;
+  const reducedImageUrl = getGalleryPictureReducedImageUrl(apiItem.id, apiItem.width, apiItem.height);
+  const variant = getGalleryPictureVariant(apiItem.width, apiItem.height);
+  return (
+    <div className={cx('gallery-picture', `gallery-picture--${variant}`)}>
+      <img src={reducedImageUrl} alt={alt} />
+    </div>
+  );
 };
 
 export default GalleryPicture;

--- a/src/components/GalleryPicture/GalleryPicture.tsx
+++ b/src/components/GalleryPicture/GalleryPicture.tsx
@@ -11,9 +11,10 @@ type GalleryPictureProps = {
 };
 
 const GalleryPicture = ({ apiItem }: GalleryPictureProps): ReactElement => {
-  const alt = `Photo ${apiItem.author} ${apiItem.id}`;
+  const alt = `Photo by ${apiItem.author}, ID - ${apiItem.id}`;
   const reducedImageUrl = getGalleryPictureReducedImageUrl(apiItem.id, apiItem.width, apiItem.height);
   const variant = getGalleryPictureVariant(apiItem.width, apiItem.height);
+
   return (
     <div className={cx('gallery-picture', `gallery-picture--${variant}`)}>
       <img src={reducedImageUrl} alt={alt} />

--- a/src/components/GalleryPicture/GalleryPicture.types.ts
+++ b/src/components/GalleryPicture/GalleryPicture.types.ts
@@ -1,0 +1,3 @@
+import type { GALLERY_PICTURE_VARIANTS } from './GalleryPicture.enums';
+
+export type GalleryPictureVariant = (typeof GALLERY_PICTURE_VARIANTS)[keyof typeof GALLERY_PICTURE_VARIANTS];

--- a/src/components/GallerySkeleton/GallerySkeleton.module.scss
+++ b/src/components/GallerySkeleton/GallerySkeleton.module.scss
@@ -3,7 +3,7 @@
 
 .gallery-skeleton {
   @include mixins.skeleton-animation();
-
+margin: utils.rem(15);
   height: utils.rem(340);
   width: utils.rem(270);
 }

--- a/src/components/GallerySkeleton/GallerySkeleton.module.scss
+++ b/src/components/GallerySkeleton/GallerySkeleton.module.scss
@@ -2,8 +2,14 @@
 @use '/src/scss/utils/utils.scss' as utils;
 
 .gallery-skeleton {
-  @include mixins.skeleton-animation();
-margin: utils.rem(15);
-  height: utils.rem(340);
-  width: utils.rem(270);
+  grid-row: span 36;
+  padding: utils.rem(15);
+
+  &__item {
+    @include mixins.skeleton-animation();
+
+    height: 100%;
+    min-height: utils.rem(330);
+    width: 100%;
+  }
 }

--- a/src/components/GallerySkeleton/GallerySkeleton.tsx
+++ b/src/components/GallerySkeleton/GallerySkeleton.tsx
@@ -12,7 +12,7 @@ const GallerySkeleton = (): ReactElement[] => {
 
   return skeletonArray.map((_, index) => (
     // eslint-disable-next-line react/no-array-index-key
-    <div key={`${elementId}-${index}`} className={cx('skeleton', 'gallery-skeleton')} />
+    <div key={`${elementId}-${index}`} className={cx('gallery-skeleton')} />
   ));
 };
 export default GallerySkeleton;

--- a/src/components/GallerySkeleton/GallerySkeleton.tsx
+++ b/src/components/GallerySkeleton/GallerySkeleton.tsx
@@ -12,7 +12,9 @@ const GallerySkeleton = (): ReactElement[] => {
 
   return skeletonArray.map((_, index) => (
     // eslint-disable-next-line react/no-array-index-key
-    <div key={`${elementId}-${index}`} className={cx('gallery-skeleton')} />
+    <div key={`${elementId}-${index}`} className={cx('gallery-skeleton')}>
+      <div className={cx('gallery-skeleton__item')} />
+    </div>
   ));
 };
 export default GallerySkeleton;

--- a/src/components/GallerySkeleton/GallerySkeleton.tsx
+++ b/src/components/GallerySkeleton/GallerySkeleton.tsx
@@ -17,4 +17,5 @@ const GallerySkeleton = (): ReactElement[] => {
     </div>
   ));
 };
+
 export default GallerySkeleton;

--- a/src/components/Sidenav/components/Footer/Footer.tsx
+++ b/src/components/Sidenav/components/Footer/Footer.tsx
@@ -15,6 +15,7 @@ const Footer = (): ReactElement => {
       <ul className={cx('footer')} role="menubar">
         {footerOptions.map((item) => {
           const Icon = item.icon;
+
           return (
             <li key={item.name} aria-label={item.title} role="menuitem">
               <button type="button" title={item.title} onClick={item.onClick} className={cx('footer__item')}>

--- a/src/components/Sidenav/components/NavLinks/NavLinks.tsx
+++ b/src/components/Sidenav/components/NavLinks/NavLinks.tsx
@@ -8,12 +8,14 @@ const cx = classNames.bind(styles);
 
 const NavLinks = (): ReactElement => {
   const activeOption = useLocation();
+
   return (
     <nav className={cx('navlinks')} aria-label="Main Navigation">
       <ul role="menubar">
         {MENU_OPTIONS.map((item) => {
           const Icon = item.icon;
           const isActive = activeOption.pathname === `/${item.pathName}`;
+
           return (
             <li role="menuitem" key={item.name} aria-label={item.title}>
               <Link

--- a/src/components/ui/ErrorFallbackButton/ErrorFallbackButton.constants.ts
+++ b/src/components/ui/ErrorFallbackButton/ErrorFallbackButton.constants.ts
@@ -1,3 +1,5 @@
 export const ERROR_FALLBACK_BUTTON_HEADING = 'Something Went Wrong';
+
 export const ERROR_FALLBACK_BUTTON_DESCRIPTION = 'Click to try again';
+
 export const ERROR_FALLBACK_BUTTON_TITLE = 'Error! Try again';

--- a/src/context/ThemeContext.ts
+++ b/src/context/ThemeContext.ts
@@ -2,4 +2,5 @@ import { createContext } from 'react';
 import type { ThemeContextType } from './themeTypes';
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
 export default ThemeContext;

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -7,5 +7,6 @@ export default function useTheme(): ThemeContextType {
   if (!context) {
     throw new Error('useTheme can only be used inside a ThemeProvider');
   }
+
   return context;
 }

--- a/src/pages/NotFoundpage/NotFoundPage.tsx
+++ b/src/pages/NotFoundpage/NotFoundPage.tsx
@@ -13,4 +13,5 @@ const NotFoundPage = (): ReactElement => (
     </h1>
   </div>
 );
+
 export default NotFoundPage;

--- a/src/scss/app.module.scss
+++ b/src/scss/app.module.scss
@@ -9,7 +9,7 @@
   &__main {
     background-color: var(--main-bg);
     color: var(--main-color);
-    overflow: auto;
+    overflow-y: auto;
     width: 100%;
   }
 }


### PR DESCRIPTION
1. based on aspect ratio defines if it's portrait or landscape
2. gets reduced image resolution to optimize performance
3. masonry layout for portrait/landscape images
4. minor fix for skeleton loading on small resolution

- Didn't put much effort into perfecting responsiveness. 670px is cutoff for single column rendering. Autofill at some specific windows sizes makes aspect ratio look not ideal. 
- intentionally rendering page 2 because page 1 has no portrait images and masonry layout is not visible. Will be changed with infinite scroll logic anyways
ui:
<img width="1919" height="792" alt="image" src="https://github.com/user-attachments/assets/d262d8da-1a84-466d-bc41-e2e4a31805e7" />
