### PR TITLE
reverting footer component code after invlid merge conflict resolution

### DIFF
--- a/src/components/Sidenav/components/Footer/Footer.tsx
+++ b/src/components/Sidenav/components/Footer/Footer.tsx
@@ -19,21 +19,25 @@ const Footer = (): ReactElement => {
   const footerOptions = getFooterOptions(darkMode, toggleTheme, openNewsletterModal);
 
   return (
-    <nav aria-label="Footer Navigation">
-      <ul className={cx('footer')} role="menubar">
-        {footerOptions.map((item) => {
-          const Icon = item.icon;
-
-          return (
-            <li key={item.name} aria-label={item.title} role="menuitem">
-              <button type="button" title={item.title} onClick={item.onClick} className={cx('footer__item')}>
-                <Icon />
-              </button>
-            </li>
-          );
-        })}
-      </ul>
-    </nav>
+    <>
+      <footer>
+        <nav aria-label="Footer">
+          <ul className={cx('footer')} role="menubar">
+            {footerOptions.map((item) => {
+              const Icon = item.icon;
+              return (
+                <li key={item.name} aria-label={item.title} role="menuitem">
+                  <Button type="button" variant="footer" title={item.title} onClick={item.onClick}>
+                    <Icon />
+                  </Button>
+                </li>
+              );
+            })}
+          </ul>
+        </nav>
+      </footer>
+      <NewsletterModal isOpen={isOpenNewsletterModal} onClose={() => setIsOpenNewsletterModal(false)} />
+    </>
   );
 };
 


### PR DESCRIPTION
between masonry layout and newsletter merges footer component was reverted back to old code which caused 2 bugs.

1. footer buttons weren't applying color change by mode
2. newlsetter modal dialog wasn't working due to removed component reference

